### PR TITLE
allow https in srsName to lookup EPSG code

### DIFF
--- a/pygml/axisorder.py
+++ b/pygml/axisorder.py
@@ -184,8 +184,8 @@ AXISORDER_YX = {
 
 RE_CRS_CODE = re.compile(
     r'(EPSG:|'
-    r'http://www\.opengis\.net/def/crs/epsg/0/|'
-    r'http://www\.opengis\.net/gml/srs/epsg\.xml\#|'
+    r'http[s]?://www\.opengis\.net/def/crs/epsg/0/|'
+    r'http[s]?://www\.opengis\.net/gml/srs/epsg\.xml\#|'
     r'urn:EPSG:geographicCRS:|'
     r'urn:ogc:def:crs:EPSG::|'
     r'urn:ogc:def:crs:OGC::|'
@@ -201,6 +201,8 @@ def get_crs_code(crs: str) -> Union[int, str]:
             * ``EPSG:<EPSG code>``
             * ``http://www.opengis.net/def/crs/EPSG/0/<EPSG code>``
             * ``http://www.opengis.net/gml/srs/epsg.xml#<EPSG code>``
+            * ``https://www.opengis.net/def/crs/EPSG/0/<EPSG code>``
+            * ``https://www.opengis.net/gml/srs/epsg.xml#<EPSG code>``
             * ``urn:EPSG:geographicCRS:<epsg code>``
             * ``urn:ogc:def:crs:EPSG::<EPSG code>``
             * ``urn:ogc:def:crs:OGC::<EPSG code>``

--- a/tests/test_axisorder.py
+++ b/tests/test_axisorder.py
@@ -8,6 +8,8 @@ def test_get_crs_code():
     assert get_crs_code('EPSG:4326') == 4326
     assert get_crs_code('http://www.opengis.net/def/crs/EPSG/0/4326') == 4326
     assert get_crs_code('http://www.opengis.net/gml/srs/epsg.xml#4326') == 4326
+    assert get_crs_code('https://www.opengis.net/def/crs/EPSG/0/4326') == 4326
+    assert get_crs_code('https://www.opengis.net/gml/srs/epsg.xml#4326') == 4326
     assert get_crs_code('urn:EPSG:geographicCRS:4326') == 4326
     assert get_crs_code('urn:ogc:def:crs:EPSG::4326') == 4326
     assert get_crs_code('urn:ogc:def:crs:EPSG:4326') == 4326


### PR DESCRIPTION
I encountered an API that links to https://www.opengis.net/def/crs/EPSG/0/<EPSG code>

previous regex would only match on http

Kr